### PR TITLE
Fix label printing order

### DIFF
--- a/imageclassifier-add-camera/app/src/main/java/com/example/androidthings/imageclassifier/classifier/TensorFlowHelper.java
+++ b/imageclassifier-add-camera/app/src/main/java/com/example/androidthings/imageclassifier/classifier/TensorFlowHelper.java
@@ -34,6 +34,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
+import java.util.Arrays;
 
 /**
  * Helper functions for the TensorFlow image classifier.
@@ -97,7 +98,12 @@ public class TensorFlowHelper {
         }
 
         List<Recognition> results = new ArrayList<>(RESULTS_TO_SHOW);
-        for (Recognition r: sortedLabels) {
+        // Array to hold the sorted results from the PQ
+        Recognition[] sorted_results = sortedLabels.toArray(new Recognition[RESULTS_TO_SHOW]);
+        // Sort the array based on the PQ's comparator
+        Arrays.sort(sorted_results, sortedLabels.comparator());
+
+        for (Recognition r: sorted_results) {
             results.add(0, r);
         }
 

--- a/imageclassifier-add-intelligence/app/src/main/java/com/example/androidthings/imageclassifier/classifier/TensorFlowHelper.java
+++ b/imageclassifier-add-intelligence/app/src/main/java/com/example/androidthings/imageclassifier/classifier/TensorFlowHelper.java
@@ -34,6 +34,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
+import java.util.Arrays;
 
 /**
  * Helper functions for the TensorFlow image classifier.
@@ -97,7 +98,12 @@ public class TensorFlowHelper {
         }
 
         List<Recognition> results = new ArrayList<>(RESULTS_TO_SHOW);
-        for (Recognition r: sortedLabels) {
+        // Array to hold the sorted results from the PQ
+        Recognition[] sorted_results = sortedLabels.toArray(new Recognition[RESULTS_TO_SHOW]);
+        // Sort the array based on the PQ's comparator
+        Arrays.sort(sorted_results, sortedLabels.comparator());
+
+        for (Recognition r: sorted_results) {
             results.add(0, r);
         }
 

--- a/imageclassifier-start/app/src/main/java/com/example/androidthings/imageclassifier/classifier/TensorFlowHelper.java
+++ b/imageclassifier-start/app/src/main/java/com/example/androidthings/imageclassifier/classifier/TensorFlowHelper.java
@@ -34,6 +34,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
+import java.util.Arrays;
 
 /**
  * Helper functions for the TensorFlow image classifier.
@@ -97,7 +98,12 @@ public class TensorFlowHelper {
         }
 
         List<Recognition> results = new ArrayList<>(RESULTS_TO_SHOW);
-        for (Recognition r: sortedLabels) {
+        // Array to hold the sorted results from the PQ
+        Recognition[] sorted_results = sortedLabels.toArray(new Recognition[RESULTS_TO_SHOW]);
+        // Sort the array based on the PQ's comparator
+        Arrays.sort(sorted_results, sortedLabels.comparator());
+
+        for (Recognition r: sorted_results) {
             results.add(0, r);
         }
 


### PR DESCRIPTION
There is a bug here causing predicted labels to be printed in incorrect order. Traversing a `java.util.PriorityQueue` with a range-based for loop does not guarantee traversal in sorted order. Fixed by converting PQ to array, sorting array with PQ`.comparator()`, and returning the results in sorted order.

More information on the undefined behavior of traversing PQ [here](https://stackoverflow.com/questions/8129122/how-to-iterate-over-a-priorityqueue).